### PR TITLE
Implement missing protocols.

### DIFF
--- a/lib/ToyPad.js
+++ b/lib/ToyPad.js
@@ -126,6 +126,11 @@ ToyPad.prototype.colorAll = function(rgb1,rgb2,rgb3,cb){
 	this.request(this.CMD_COLAL,new Buffer([rgb1.r,rgb1.g,rgb1.b,rgb2.r,rgb2.g,rgb2.b,rgb3.r,rgb3.g,rgb3.b]),cb)
 }
 
+ToyPad.prototype.getPadColor = function(pad,cb){
+	// Subtract 1 here to match the Pad values used in color (1,2,3)
+	this.request(this.CMD_GETCOL,new Buffer([pad-1]),cb)
+}
+
 ToyPad.prototype.fade = function(p,s,rgb,cb){
 	rgb = hextorgb(rgb)
 	this.request(this.CMD_FADE,new Buffer([p,s,c,rgb.r,rgb.g,rgb.b]),cb)	
@@ -142,9 +147,10 @@ ToyPad.prototype.fadeAll = function(s1,c1,rgb1,s2,c2,rgb2,s3,c3,rgb3,cb){
 	this.request(this.CMD_FADAL,new Buffer([1,s1,c1,rgb1.r,rgb1.g,rgb1.b,1,s2,c2,rgb2.r,rgb2.g,rgb2.b,1,s3,c3,rgb3.r,rgb3.g,rgb3.b]),cb)
 }
 
-ToyPad.prototype.flash = function(c,rgb,cb){
-	rgb = hextorgb(rgb)
-	this.request(this.CMD_FLASH,new Buffer([c,rgb.r,rgb.g,rgb.b]),cb)	
+// onoff how long it stays off and on, [5,10] would mean it stays off-color 5 ticks, previous color 10 ticks.
+ToyPad.prototype.flash = function(pad,onoff,count,offRGB,cb){
+	rgb = hextorgb(offRGB)
+	this.request(this.CMD_FLASH,new Buffer([pad,onoff[0],onoff[1],count,rgb.r,rgb.g,rgb.b]),cb)	
 }
 
 ToyPad.prototype.flashAll = function(onoff1,a1,rgb1,onoff2,a2,rgb2,onoff3,a3,rgb3,cb){
@@ -174,12 +180,26 @@ ToyPad.prototype.model = function(data,cb){
 	this.request(this.CMD_MODEL,data,cb)
 }
 
-ToyPad.prototype.E1 = function(data,cb){
-	this.request(this.CMD_E1,data,cb)
+// The Lego pad automatically sends a PWD based on UID of the tag.
+// This CMD appears to configure this feature, valid types are:
+// 0 - Disable PWD Send, 1 - Enable default PWD algorithm, 2 - Custom PWD sent as 4 bytes
+// The index argument appears to not function properly (it will error if there is no tag on given index), but some indexes are always valid such as 84, if anyone knows why...
+// The effect is global until another PWD change
+ToyPad.prototype.pwd = function(type,pwd,cb){
+	var buf = new Buffer(6)
+	if (type < 2)
+		buf.fill(0)
+	else
+		pwd.copy(buf,1)
+	buf[0] = 84 //Possible tag index?
+	buf[1] = type
+	this.request(this.CMD_PWD,buf,cb)
 }
 
-ToyPad.prototype.E5 = function(data,cb){
-	this.request(this.CMD_E5,data,cb)
+// This appears to halt NFC operations until another read/write/pause is called.
+// State values: 0 - Pause, 1 - Unpause
+ToyPad.prototype.pause = function(state,cb){
+	this.request(this.CMD_PAUSE,state,cb)
 }
 
 function hextorgb(hex){

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,7 +3,9 @@ var commands = {
 	CMD_SEED  : 0xB1,
 	CMD_CHAL  : 0xB3,
 	CMD_COL   : 0xC0,
+	CMD_GETCOL: 0xC1,
 	CMD_FADE  : 0xC2,
+	CMD_FLASH : 0xC3,
 	CMD_FADRD : 0xC4,
 	CMD_FADAL : 0xC6,
 	CMD_FLSAL : 0xC7,
@@ -12,8 +14,8 @@ var commands = {
 	CMD_READ  : 0xD2,
 	CMD_WRITE : 0xD3,
 	CMD_MODEL : 0xD4,
-	CMD_E1    : 0xE1,
-	CMD_E5    : 0xE5,
+	CMD_PWD   : 0xE1,
+	CMD_PAUSE : 0xE5,
 	CMD_LEDSQ : 0xFF,
 }
 function attachConstants(obj){


### PR DESCRIPTION
C1 (Gets RGB color, was this supposed to be LEDSQ?)
C3 (FLASH existed in ToyPad but was wrong and missing)
E1 (Controls PWD usage by the pad, this in theory enables the pad to be a universal NTAG21* read/writer)
E5 (Halts NFC events until another is received)