### PR TITLE
Typo lost during transferring.

### DIFF
--- a/lib/ToyPad.js
+++ b/lib/ToyPad.js
@@ -190,7 +190,7 @@ ToyPad.prototype.pwd = function(type,pwd,cb){
 	if (type < 2)
 		buf.fill(0)
 	else
-		pwd.copy(buf,1)
+		pwd.copy(buf,2)
 	buf[0] = 84 //Possible tag index?
 	buf[1] = type
 	this.request(this.CMD_PWD,buf,cb)


### PR DESCRIPTION
You accepted it so fast or I would have ammended it.
Sorry.